### PR TITLE
[DM-26505] Rename docker image to ops-linters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/lsst-sqre/linters:${{ steps.vars.outputs.tag }}
+          tags: ghcr.io/lsst-sqre/ops-linters:${{ steps.vars.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Maybe this will get around some auth problems we've been having.