### PR TITLE
[DM-26505] Use github_token instead of GHCR_TOKEN

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,8 +49,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: token
-          password: ${{ secrets.GHCR_PUSH_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v3


### PR DESCRIPTION
We're still working on having the image be public.